### PR TITLE
pass whole CR to k-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,23 @@ manifests-root
 It works based on CR config yaml in environment variable `YAML_CONF`. The CR config looks like this
 
 ```yaml
-profile: base
-manifestsRoot: "/cnab/app"
-storageClassName: efs
-namespace: whatever
-rotateKeys: "yes"|"None"|"no" 
-# yes: generate keys and store in k8s, None: use default keys which is in EJSON_KEY env, no: restore key from k8s cluster
-configs:
-  qliksense:
-  - name: acceptEULA
-    value: "yes"
-secrets:
-  qliksense:
-  - name: mongoDbUri
-    value: mongo://mongo:3307
+apiVersion: qlik.com/v1
+kind: Qliksense
+metadata:
+  name: test-cr  # all the resources are prefixed with this name
+  namespace: test-ns
+spec:
+  profile: base
+  manifestsRoot: "/cnab/app"
+  storageClassName: efs
+  rotateKeys: "yes"|"None"|"no"
+  # yes: generate keys and store in k8s, None: use default keys which is in EJSON_KEY env, no: restore key from k8s cluster
+  configs:
+    qliksense:
+    - name: acceptEULA
+      value: "yes"
+  secrets:
+    qliksense:
+    - name: mongoDbUri
+      value: mongo://mongo:3307
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,23 +19,23 @@ import (
 )
 
 // ReadCRSpecFromFile return CR config from yaml file
-func ReadCRSpecFromFile(file io.Reader) (*CRSpec, error) {
+func ReadCRSpecFromFile(file io.Reader) (*KApiCr, error) {
 	content, err := ioutil.ReadAll(file)
 	if err != nil {
 		log.Fatal(err)
 	}
-	cr := CRSpec{}
-	err = yaml.Unmarshal(content, &cr)
+	kCr := KApiCr{}
+	err = yaml.Unmarshal(content, &kCr)
 	if err != nil {
 		log.Fatal(err)
 		return nil, err
 	}
 
-	return &cr, nil
+	return &kCr, nil
 }
 
 // ReadCRSpecFromEnvYaml return CR config from env yaml
-func ReadCRSpecFromEnvYaml() (*CRSpec, error) {
+func ReadCRSpecFromEnvYaml() (*KApiCr, error) {
 	content := os.Getenv("YAML_CONF")
 	if content == "" {
 		return nil, errors.New("YAML_CONF env cannot be empty")
@@ -178,7 +178,17 @@ func (in *CRSpec) DeepCopy() *CRSpec {
 	in.DeepCopyInto(out)
 	return out
 }
-
+func (in *KApiCr) DeepCopyInto(out *KApiCr) {
+	copier.Copy(out, in)
+}
+func (in *KApiCr) DeepCopy() *KApiCr {
+	if in == nil {
+		return nil
+	}
+	out := new(KApiCr)
+	in.DeepCopyInto(out)
+	return out
+}
 func (cr *CRSpec) GetManifestsRoot() string {
 	return cr.ManifestsRoot
 }

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/kustomize/api/types"
 )
 
@@ -16,9 +17,13 @@ type CRSpec struct {
 	ManifestsRoot    string                `json:"manifestsRoot,omitempty" yaml:"manifestsRoot,omitempty"`
 	RotateKeys       string                `json:"rotateKeys,omitempty" yaml:"rotateKeys,omitempty"`
 	StorageClassName string                `json:"storageClassName,omitempty" yaml:"storageClassName,omitempty"`
-	NameSpace        string                `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Git              Repo                  `json:"git,omitempty" yaml:"git,omitempty"`
-	ReleaseName      string                `json:"releaseName,omitempty" yaml:"releaseName,omitempty"`
+}
+
+type KApiCr struct {
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Spec              *CRSpec `json:"spec" yaml:"spec"`
 }
 
 type SelectivePatch struct {

--- a/pkg/qust/patch_configs_test.go
+++ b/pkg/qust/patch_configs_test.go
@@ -17,7 +17,7 @@ func TestCreateSupperConfigSelectivePatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading config from file")
 	}
-	spMap := createSupperConfigSelectivePatch(cfg.Configs)
+	spMap := createSupperConfigSelectivePatch(cfg.Spec.Configs)
 	sp := spMap["qliksense"]
 	if sp.ApiVersion != "qlik.com/v1" {
 		t.Fail()
@@ -57,9 +57,9 @@ func TestProcessConfigs(t *testing.T) {
 
 	td, dir := createManifestsStructure(t)
 
-	cfg.ManifestsRoot = dir
+	cfg.Spec.ManifestsRoot = dir
 
-	ProcessConfigs(cfg)
+	ProcessConfigs(cfg.Spec)
 	content, _ := ioutil.ReadFile(filepath.Join(dir, ".operator", "configs", "qliksense.yaml"))
 
 	sp := getSuperConfigSPTemplate("qliksense")

--- a/pkg/qust/patch_namespace.go
+++ b/pkg/qust/patch_namespace.go
@@ -10,15 +10,15 @@ import (
 )
 
 // It will patch the built-in NamespaceTransformer
-func ProcessNamespace(cr *config.CRSpec) error {
-	if cr.NameSpace == "" {
+func ProcessNamespace(cr *config.KApiCr) error {
+	if cr.GetObjectMeta().GetNamespace() == "" {
 		// no namespace provided so default should work
 		return nil
 	}
-	namespacePatchFileName := "namespace-" + cr.NameSpace + ".yaml"
+	namespacePatchFileName := "namespace-" + cr.GetObjectMeta().GetNamespace() + ".yaml"
 
-	fileFullPath := filepath.Join(cr.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", namespacePatchFileName)
-	fileContents := strings.Replace(namespacePatchTemplate(), "NAMESPACE_NAME", cr.NameSpace, 1)
+	fileFullPath := filepath.Join(cr.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", namespacePatchFileName)
+	fileContents := strings.Replace(namespacePatchTemplate(), "NAMESPACE_NAME", cr.GetObjectMeta().GetNamespace(), 1)
 
 	err := ioutil.WriteFile(fileFullPath, []byte(fileContents), FILE_PERMISION)
 
@@ -27,7 +27,7 @@ func ProcessNamespace(cr *config.CRSpec) error {
 		return err
 	}
 	// add that file to kustomization.yaml
-	fileFullPath = filepath.Join(cr.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "kustomization.yaml")
+	fileFullPath = filepath.Join(cr.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "kustomization.yaml")
 	err = addResourceToKustomization(namespacePatchFileName, fileFullPath)
 	if err != nil {
 		log.Panic("Cannot add resource to "+fileFullPath, err)

--- a/pkg/qust/patch_namespace_test.go
+++ b/pkg/qust/patch_namespace_test.go
@@ -18,18 +18,18 @@ func TestProcessNamespace(t *testing.T) {
 	}
 	// create manifests structure
 	td, dir := createManifestsStructure(t)
-	cfg.ManifestsRoot = dir
+	cfg.Spec.ManifestsRoot = dir
 	myNs := "test-ns"
-	cfg.NameSpace = myNs
+	cfg.GetObjectMeta().SetNamespace(myNs)
 
 	err = ProcessNamespace(cfg)
 	if err != nil {
 		td()
 		t.FailNow()
 	}
-	nsFileName := "namespace-" + cfg.NameSpace + ".yaml"
-	nsFileFullPath := filepath.Join(cfg.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", nsFileName)
-	kustFile := filepath.Join(cfg.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "kustomization.yaml")
+	nsFileName := "namespace-" + cfg.GetObjectMeta().GetNamespace() + ".yaml"
+	nsFileFullPath := filepath.Join(cfg.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", nsFileName)
+	kustFile := filepath.Join(cfg.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "kustomization.yaml")
 
 	if !strings.Contains(getFileContent(nsFileFullPath, t), myNs) {
 		t.Log("Namespace patch file not patch")

--- a/pkg/qust/patch_release_name.go
+++ b/pkg/qust/patch_release_name.go
@@ -1,11 +1,12 @@
 package qust
 
 import (
-	"github.com/qlik-oss/k-apis/pkg/config"
 	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/qlik-oss/k-apis/pkg/config"
 )
 
 const (
@@ -13,26 +14,26 @@ const (
 )
 
 // It will create patch for releaseName
-func ProcessReleaseName(cr *config.CRSpec) error {
-	if cr.ReleaseName == "" {
+func ProcessReleaseName(cr *config.KApiCr) error {
+	if cr.GetObjectMeta().GetName() == "" {
 		// no release name defined (default qliksense will be used)
 		return nil
 	}
-	transFolder := filepath.Join(cr.GetManifestsRoot(), operatorPatchBaseFolder, "transformers")
+	transFolder := filepath.Join(cr.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers")
 	releaseTemplateFile := filepath.Join(transFolder, releaseTemplateFileName)
-	releaseFileName := filepath.Join(transFolder, cr.ReleaseName+".yaml")
+	releaseFileName := filepath.Join(transFolder, cr.GetObjectMeta().GetName()+".yaml")
 	content, err := ioutil.ReadFile(releaseTemplateFile)
 	if err != nil {
 		log.Println("cannot read "+releaseTemplateFile, err)
 		return err
 	}
-	result := strings.Replace(string(content), "release-template", cr.ReleaseName, 1)
-	result = strings.Replace(string(content), "release: qliksense", "release: "+cr.ReleaseName, 1)
+	result := strings.Replace(string(content), "release-template", cr.GetObjectMeta().GetName(), 1)
+	result = strings.Replace(string(content), "release: qliksense", "release: "+cr.GetObjectMeta().GetName(), 1)
 	if err = ioutil.WriteFile(releaseFileName, []byte(result), 0644); err != nil {
 		log.Println("cannot write file " + releaseFileName)
 		return err
 	}
-	if err = addResourceToKustomization(cr.ReleaseName+".yaml", filepath.Join(transFolder, "kustomization.yaml")); err != nil {
+	if err = addResourceToKustomization(cr.GetObjectMeta().GetName()+".yaml", filepath.Join(transFolder, "kustomization.yaml")); err != nil {
 		log.Println("Cannot process configs", err)
 		return err
 	}

--- a/pkg/qust/patch_release_name_test.go
+++ b/pkg/qust/patch_release_name_test.go
@@ -17,11 +17,11 @@ func TestProcessReleaseName(t *testing.T) {
 	}
 	// create manifests structure
 	_, dir := createManifestsStructure(t)
-	cfg.ManifestsRoot = dir
+	cfg.Spec.ManifestsRoot = dir
 
-	releaseFileName := filepath.Join(cfg.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "new-release.yaml")
+	releaseFileName := filepath.Join(cfg.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "new-release.yaml")
 
-	cfg.ReleaseName = "new-release"
+	cfg.GetObjectMeta().SetName("new-release")
 	err = ProcessReleaseName(cfg)
 
 	newCount := strings.Count(getFileContent(releaseFileName, t), "release: new-release")

--- a/pkg/qust/patch_secrets_test.go
+++ b/pkg/qust/patch_secrets_test.go
@@ -17,7 +17,7 @@ func TestCreateSupperSecretSelectivePatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading config from file")
 	}
-	spMap := createSupperSecretSelectivePatch(cfg.Secrets)
+	spMap := createSupperSecretSelectivePatch(cfg.Spec.Secrets)
 	sp := spMap["qliksense"]
 	if sp.ApiVersion != "qlik.com/v1" {
 		t.Fail()
@@ -60,8 +60,8 @@ func TestProcessCrSecrets(t *testing.T) {
 
 	td, dir := createManifestsStructure(t)
 
-	cfg.ManifestsRoot = dir
-	ProcessSecrets(cfg)
+	cfg.Spec.ManifestsRoot = dir
+	ProcessSecrets(cfg.Spec)
 	content, _ := ioutil.ReadFile(filepath.Join(dir, ".operator", "secrets", "qliksense.yaml"))
 
 	sp := getSuperSecretSPTemplate("qliksense")

--- a/pkg/qust/patch_storage_class_test.go
+++ b/pkg/qust/patch_storage_class_test.go
@@ -17,32 +17,32 @@ func TestProcessStorageClassName(t *testing.T) {
 	}
 	// create manifests structure
 	td, dir := createManifestsStructure(t)
-	cfg.ManifestsRoot = dir
+	cfg.Spec.ManifestsRoot = dir
 
-	storageClassFileName := filepath.Join(cfg.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "storage-class.yaml")
+	storageClassFileName := filepath.Join(cfg.Spec.GetManifestsRoot(), operatorPatchBaseFolder, "transformers", "storage-class.yaml")
 
 	oldCount := strings.Count(getFileContent(storageClassFileName, t), "value: false")
 	if oldCount <= 0 {
 		t.Log("value: false not found in " + storageClassFileName)
 		t.FailNow()
 	}
-	cfg.StorageClassName = ""
-	err = ProcessStorageClassName(cfg)
+	cfg.Spec.StorageClassName = ""
+	err = ProcessStorageClassName(cfg.Spec)
 
 	newCount := strings.Count(getFileContent(storageClassFileName, t), "value: true")
 
 	if newCount != 0 {
 		t.Fail()
 	}
-	cfg.StorageClassName = "efs"
-	err = ProcessStorageClassName(cfg)
+	cfg.Spec.StorageClassName = "efs"
+	err = ProcessStorageClassName(cfg.Spec)
 
 	newCount = strings.Count(getFileContent(storageClassFileName, t), "value: true")
 
 	if newCount != oldCount {
 		t.Fail()
 	}
-	cfg.StorageClassName = ""
+	cfg.Spec.StorageClassName = ""
 
 	td()
 }

--- a/pkg/qust/patch_utils_test.go
+++ b/pkg/qust/patch_utils_test.go
@@ -36,18 +36,23 @@ resources:
 func setupCr(t *testing.T) io.Reader {
 	t.Parallel()
 	sampleConfig := `
-profile: base
-manifestsRoot: "."
-storageClassName: "efs"
-releaseName: "testing"
-configs:
-  qliksense:
-  - name: acceptEULA
-    value: "yes"
-secrets:
-  qliksense:
-  - name: mongoDbUri
-    value: mongo://mongo:3307`
+apiVersion: qlik.com/v1
+kind: Qliksense
+metadata:
+  name: "testing"
+  namespace: "testing-namespace"
+spec:
+  profile: base
+  manifestsRoot: "."
+  storageClassName: "efs"
+  configs:
+    qliksense:
+    - name: acceptEULA
+      value: "yes"
+  secrets:
+    qliksense:
+    - name: mongoDbUri
+      value: mongo://mongo:3307`
 	os.Setenv("YAML_CONF", sampleConfig)
 	return strings.NewReader(sampleConfig)
 }


### PR DESCRIPTION
k-api expect the whole CR as opposed to only spec of CR.
```yaml
..........
metadata:
  name: testing # all the resources are prefixed with this name
  namespace: test-ns. # patch created for this namespace

..............
```


Signed-off-by: Foysal Iqbal <mqb@qlik.com>