### PR TITLE
[WIP] Saving and retrieving secret values as base64 encoded multiline strings

### DIFF
--- a/pkg/qust/patch_secrets_test.go
+++ b/pkg/qust/patch_secrets_test.go
@@ -43,7 +43,7 @@ func TestCreateSupperSecretSelectivePatch(t *testing.T) {
 			"name": "qliksense-secrets",
 		},
 		StringData: map[string]string{
-			"mongoDbUri": `(( (ds "data").mongoDbUri | regexp.Replace "[\r\n]+" "\\n" | strings.Squote | strings.TrimPrefix "'" | strings.TrimSuffix "'" ))`,
+			"mongoDbUri": `((- "\n"))(( index (ds "data") "mongoDbUri" | base64.Decode | indent 8 ))` + "\n",
 		},
 	}
 	ss2 := &config.SupperSecret{}
@@ -82,7 +82,7 @@ func TestProcessCrSecrets(t *testing.T) {
 	sp := getSuperSecretSPTemplate("qliksense")
 	scm := getSuperSecretTemplate("qliksense")
 	scm.StringData = map[string]string{
-		"mongoDbUri": `(( (ds "data").mongoDbUri | regexp.Replace "[\r\n]+" "\\n" | strings.Squote | strings.TrimPrefix "'" | strings.TrimSuffix "'" ))`,
+		"mongoDbUri": `((- "\n"))(( index (ds "data") "mongoDbUri" | base64.Decode | indent 8 ))` + "\n",
 	}
 	phb, _ := yaml.Marshal(scm)
 	sp.Patches = []types.Patch{


### PR DESCRIPTION
Generates secret patches that look like this:
```
apiVersion: qlik.com/v1
kind: SelectivePatch
metadata:
  name: identity-providers-generated-operator-secrets
enabled: true
patches:
- patch: |
    apiVersion: qlik.com/v1
    kind: SuperSecret
    metadata:
      name: identity-providers-secrets
    stringData:
      idpConfigs: |
        ((- "\n"))(( index (ds "data") "idpConfigs" | base64.Decode | indent 8 ))
  target:
    kind: SuperSecret
    labelSelector: app=identity-providers
```
