### PR TITLE
fix multiline issue

### DIFF
--- a/pkg/qust/patch_secrets.go
+++ b/pkg/qust/patch_secrets.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -101,7 +102,7 @@ func getSecretPatchBody(svc string, nv config.NameValue) types.Patch {
 	}
 	phb, _ := yaml.Marshal(ph)
 	p1 := types.Patch{
-		Patch:  string(phb),
+		Patch:  strings.Replace(string(phb), ": |", ": |-", -1), // when load again the |- will disappaer and the value will be on one line
 		Target: getSelector("SuperSecret", svc),
 	}
 	return p1

--- a/pkg/qust/patch_secrets_test.go
+++ b/pkg/qust/patch_secrets_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Shopify/ejson"
@@ -43,12 +44,14 @@ func TestCreateSupperSecretSelectivePatch(t *testing.T) {
 			"name": "qliksense-secrets",
 		},
 		StringData: map[string]string{
-			"mongoDbUri": `((- "\n"))(( index (ds "data") "mongoDbUri" | base64.Decode | indent 8 ))` + "\n",
+			"mongoDbUri": `((- "\n"))(( index (ds "data") "mongoDbUri" | base64.Decode | indent 8 ))`,
 		},
 	}
 	ss2 := &config.SupperSecret{}
-	yaml.Unmarshal([]byte(sp.Patches[0].Patch), ss2)
-
+	if err := yaml.Unmarshal([]byte(sp.Patches[0].Patch), ss2); err != nil {
+		t.Fail()
+		t.Log(err)
+	}
 	if !reflect.DeepEqual(ss, ss2) {
 		t.Fail()
 		t.Log("expected selectivePatch: ", ss)
@@ -87,7 +90,7 @@ func TestProcessCrSecrets(t *testing.T) {
 	phb, _ := yaml.Marshal(scm)
 	sp.Patches = []types.Patch{
 		{
-			Patch:  string(phb),
+			Patch:  strings.Replace(string(phb), ": |", ": |-", -1),
 			Target: getSelector("SuperSecret", "qliksense"),
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Foysal Iqbal <mqb@qlik.com>

The only problems is if we have something the file like this
```
apiVersion: qlik.com/v1
kind: SelectivePatch
metadata:
  name: identity-providers-generated-operator-secrets
enabled: true
patches:
- patch: |
    apiVersion: qlik.com/v1
    kind: SuperSecret
    metadata:
      name: identity-providers-secrets
    stringData:
      idpConfigs: |-
        ((- "\n"))(( index (ds "data") "idpConfigs" | base64.Decode | indent 8 ))
  target:
    kind: SuperSecret
    labelSelector: app=identity-providers
```
if we Unmarshal to struct then write again, it will be like this
```
apiVersion: qlik.com/v1
kind: SelectivePatch
metadata:
  name: identity-providers-generated-operator-secrets
enabled: true
patches:
- patch: |
    apiVersion: qlik.com/v1
    kind: SuperSecret
    metadata:
      name: identity-providers-secrets
    stringData:
      idpConfigs: ((- "\n"))(( index (ds "data") "idpConfigs" | base64.Decode | indent 8 ))
  target:
    kind: SuperSecret
    labelSelector: app=identity-providers
```