### PR TITLE
Rotating additional application secrets

### DIFF
--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -16,11 +16,12 @@ type CRSpec struct {
 	Configs          map[string]NameValues `json:"configs,omitempty" yaml:"configs,omitempty"`
 	ManifestsRoot    string                `json:"manifestsRoot,omitempty" yaml:"manifestsRoot,omitempty"`
 	RotateKeys       string                `json:"rotateKeys,omitempty" yaml:"rotateKeys,omitempty"`
-	TlsCertHostName  string                `json:"tlsCertHostName,omitempty" yaml:"tlsCertHostName,omitempty"`
 	StorageClassName string                `json:"storageClassName,omitempty" yaml:"storageClassName,omitempty"`
 	Git              *Repo                 `json:"git,omitempty" yaml:"git,omitempty"`
 	OpsRunner        *OpsRunner            `json:"opsRunner,omitempty" yaml:"opsRunner,omitempty"`
 	FetchSource      *Repo                 `json:"fetchSource,omitempty" yaml:"fetchSource,omitempty"`
+	TlsCertHost      string                `json:"tlsCertHost,omitempty" yaml:"tlsCertHost,omitempty"`
+	TlsCertOrg       string                `json:"tlsCertOrg,omitempty" yaml:"tlsCertOrg,omitempty"`
 }
 
 type KApiCr struct {

--- a/pkg/config/type.go
+++ b/pkg/config/type.go
@@ -16,6 +16,7 @@ type CRSpec struct {
 	Configs          map[string]NameValues `json:"configs,omitempty" yaml:"configs,omitempty"`
 	ManifestsRoot    string                `json:"manifestsRoot,omitempty" yaml:"manifestsRoot,omitempty"`
 	RotateKeys       string                `json:"rotateKeys,omitempty" yaml:"rotateKeys,omitempty"`
+	TlsCertHostName  string                `json:"tlsCertHostName,omitempty" yaml:"tlsCertHostName,omitempty"`
 	StorageClassName string                `json:"storageClassName,omitempty" yaml:"storageClassName,omitempty"`
 	Git              *Repo                 `json:"git,omitempty" yaml:"git,omitempty"`
 	OpsRunner        *OpsRunner            `json:"opsRunner,omitempty" yaml:"opsRunner,omitempty"`

--- a/pkg/keys/generator.go
+++ b/pkg/keys/generator.go
@@ -5,10 +5,15 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
 
 	"gopkg.in/square/go-jose.v2"
 )
@@ -102,4 +107,43 @@ func Generate() (privateKeyPem string, keyId string, jwks string, err error) {
 
 	jwks, err = getJwks(privateKey.Public().(*ecdsa.PublicKey), keyId)
 	return privateKeyPem, keyId, jwks, nil
+}
+
+func GetSelfSignedCertAndKey(name, organization string, validity time.Duration) (certificate, key []byte, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ailed to generate serial number: %s", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   name,
+			Organization: []string{organization},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(validity),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{name, fmt.Sprintf("*.%v", name)},
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %s", err)
+	}
+	certificate = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to marshal private key: %v", err)
+	}
+	key = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+
+	return certificate, key, nil
 }

--- a/pkg/keys/generator.go
+++ b/pkg/keys/generator.go
@@ -18,6 +18,11 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
+const (
+	defaultCertCommonName   = "elastic.example"
+	defaultCertOrganization = "elastic-local-cert"
+)
+
 type jsonWebKeySetT struct {
 	Keys []map[string]interface{} `json:"keys"`
 }
@@ -110,6 +115,12 @@ func Generate() (privateKeyPem string, keyId string, jwks string, err error) {
 }
 
 func GetSelfSignedCertAndKey(commonName, organization string, validity time.Duration) (certificate, key []byte, err error) {
+	if commonName == "" {
+		commonName = defaultCertCommonName
+	}
+	if organization == "" {
+		organization = defaultCertOrganization
+	}
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/keys/generator.go
+++ b/pkg/keys/generator.go
@@ -109,7 +109,7 @@ func Generate() (privateKeyPem string, keyId string, jwks string, err error) {
 	return privateKeyPem, keyId, jwks, nil
 }
 
-func GetSelfSignedCertAndKey(name, organization string, validity time.Duration) (certificate, key []byte, err error) {
+func GetSelfSignedCertAndKey(commonName, organization string, validity time.Duration) (certificate, key []byte, err error) {
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return nil, nil, err
@@ -122,7 +122,7 @@ func GetSelfSignedCertAndKey(name, organization string, validity time.Duration) 
 	template := x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName:   name,
+			CommonName:   commonName,
 			Organization: []string{organization},
 		},
 		NotBefore:             time.Now(),
@@ -130,7 +130,7 @@ func GetSelfSignedCertAndKey(name, organization string, validity time.Duration) 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		DNSNames:              []string{name, fmt.Sprintf("*.%v", name)},
+		DNSNames:              []string{commonName, fmt.Sprintf("*.%v", commonName)},
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)

--- a/pkg/keys/generator_test.go
+++ b/pkg/keys/generator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -28,4 +29,16 @@ func TestGenerate(t *testing.T) {
 	assert.Equal(t, keyId, jwksKeyMap["kid"])
 	assert.Contains(t, jwksKeyMap["pem"], "-----BEGIN PUBLIC KEY-----")
 	assert.Contains(t, jwksKeyMap["pem"], "-----END PUBLIC KEY-----")
+}
+
+func Test_getSelfSignedCertAndKey(t *testing.T) {
+	host := "elastic.example"
+	org := "elastic-local-cert"
+	validity := time.Hour * 24 * 365 * 10
+	selfSignedCert, key, err := GetSelfSignedCertAndKey(host, org, validity)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	fmt.Print(string(selfSignedCert))
+	fmt.Print(string(key))
 }

--- a/pkg/qust/patch_keys.go
+++ b/pkg/qust/patch_keys.go
@@ -72,7 +72,7 @@ func overrideServiceEpriviteKeyJsonFile(cr *config.CRSpec, service *serviceT, ej
 	ePriviteKeyMap["_public_key"] = ejsonPublicKey
 
 	if service.Name == "elastic-infra" {
-		if certPem, keyPem, err := keys.GetSelfSignedCertAndKey(cr.TlsCertHost, cr.TlsCertOrg, time.Hour*24*365*50); err != nil {
+		if certPem, keyPem, err := keys.GetSelfSignedCertAndKey(cr.TlsCertHost, cr.TlsCertOrg, time.Hour*24*365*10); err != nil {
 			return err
 		} else {
 			ePriviteKeyMap["tls_cert"] = base64.StdEncoding.EncodeToString(certPem)

--- a/pkg/qust/patch_keys.go
+++ b/pkg/qust/patch_keys.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Shopify/ejson"
 	"github.com/qlik-oss/k-apis/pkg/config"
@@ -68,8 +70,33 @@ func initServiceList(cr *config.CRSpec) ([]*serviceT, error) {
 func overrideServiceEpriviteKeyJsonFile(cr *config.CRSpec, service *serviceT, ejsonPublicKey string) error {
 	ePriviteKeyMap := make(map[string]string)
 	ePriviteKeyMap["_public_key"] = ejsonPublicKey
-	ePriviteKeyMap["private_key"] = service.PrivateKey
-	ePriviteKeyMap["kid"] = service.Kid
+
+	if service.Name == "elastic-infra" {
+		if certPem, keyPem, err := keys.GetSelfSignedCertAndKey(cr.TlsCertHost, cr.TlsCertOrg, time.Hour*24*365*50); err != nil {
+			return err
+		} else {
+			ePriviteKeyMap["tls_cert"] = base64.StdEncoding.EncodeToString(certPem)
+			ePriviteKeyMap["tls_key"] = base64.StdEncoding.EncodeToString(keyPem)
+		}
+	} else {
+		ePriviteKeyMap["private_key"] = service.PrivateKey
+		ePriviteKeyMap["kid"] = service.Kid
+
+		if service.Name == "edge-auth" {
+			loginStateKey := make([]byte, 32)
+			if _, err := rand.Read(loginStateKey); err != nil {
+				return err
+			} else {
+				ePriviteKeyMap["login_state_key"] = base64.StdEncoding.EncodeToString(loginStateKey)
+			}
+			cookieKey := make([]byte, 32)
+			if _, err := rand.Read(cookieKey); err != nil {
+				return err
+			} else {
+				ePriviteKeyMap["cookies_keys"] = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`["%v"]`, base64.StdEncoding.EncodeToString(loginStateKey))))
+			}
+		}
+	}
 
 	if err := writeToEjsonFile(ePriviteKeyMap, filepath.Join(cr.GetManifestsRoot(), operatorPatchBaseFolder,
 		operatorKeysBaseFolder, "secrets", service.Name, "eprivate_key.json")); err != nil {
@@ -82,7 +109,9 @@ func overrideKeysEjwksJsonFile(cr *config.CRSpec, services []*serviceT, ejsonPub
 	eJwksMap := make(map[string]string)
 	eJwksMap["_public_key"] = ejsonPublicKey
 	for _, service := range services {
-		eJwksMap[service.Name] = base64.StdEncoding.EncodeToString([]byte(service.JWKS))
+		if service.Name != "elastic-infra" {
+			eJwksMap[service.Name] = base64.StdEncoding.EncodeToString([]byte(service.JWKS))
+		}
 	}
 
 	if err := writeToEjsonFile(eJwksMap, filepath.Join(cr.GetManifestsRoot(), operatorPatchBaseFolder,
@@ -144,11 +173,13 @@ func updateSelectivePatchYaml(selectivePatchYamlBytes []byte, services []*servic
 					//create and append a new "data" element:
 					dataMapItems := yaml.MapItem{Key: "data", Value: make([]yaml.MapItem, 0)}
 					for _, service := range services {
-						// adding "\n" to the end of the value string to force the block scalar yaml format:
-						dataMapItems.Value = append(dataMapItems.Value.([]yaml.MapItem), yaml.MapItem{
-							Key:   fmt.Sprintf("qlik.api.internal-%v", service.Name),
-							Value: fmt.Sprintf(`(( index (ds "data") "%v" | base64.Decode ))`, service.Name) + "\n",
-						})
+						if service.Name != "elastic-infra" {
+							// adding "\n" to the end of the value string to force the block scalar yaml format:
+							dataMapItems.Value = append(dataMapItems.Value.([]yaml.MapItem), yaml.MapItem{
+								Key:   fmt.Sprintf("qlik.api.internal-%v", service.Name),
+								Value: fmt.Sprintf(`(( index (ds "data") "%v" | base64.Decode ))`, service.Name) + "\n",
+							})
+						}
 					}
 					superConfigMapSlice = append(superConfigMapSlice, dataMapItems)
 					//re-marshal SuperConfig:


### PR DESCRIPTION
Rotating the nginx cert in `elastic-infra` and `loginStateKey` and `cookiesKeys` in `edge-auth`. Backing-up/restoring these keys to/from the cluster just like the other service keys.